### PR TITLE
Add concurrently package and update dev scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
+        "concurrently": "^9.2.0",
         "globals": "^15.9.0",
         "postcss": "^8.4.47",
         "prettier": "^3.5.3",
@@ -4387,6 +4388,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -4942,6 +4973,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/cross-env": {
@@ -5557,6 +5614,16 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -6680,6 +6747,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6722,6 +6799,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -6899,6 +6989,22 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -7126,6 +7232,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/troika-three-text": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
+    "concurrently": "^9.2.0",
     "globals": "^15.9.0",
     "postcss": "^8.4.47",
     "prettier": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently \"npm run dev:server\" \"vite\"",
+    "dev:client": "vite",
+    "dev:server": "cd server && npm start",
     "build": "vite build",
     "test": "vitest --run",
     "format.fix": "prettier --write .",

--- a/src/lib/websocketSync.ts
+++ b/src/lib/websocketSync.ts
@@ -420,6 +420,13 @@ export class WebSocketMusicSync {
       callbacks.forEach((callback) => callback({ type: eventType, ...data }));
     }
   }
+
+  /**
+   * Send raw message (public method for special cases)
+   */
+  sendMessage(message: any) {
+    this.send(message);
+  }
 }
 
 // Export singleton instance

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -566,7 +566,6 @@ const WorkspacePage = () => {
             wsSync.syncSongChange(nextSong);
             setStatus("playing");
             setSyncedPosition(0);
-            setIsLocallyPaused(false);
           } else {
             // Fallback to Firebase sync
             await synchronizedPlayback.changeSong(workspaceId, nextSong);
@@ -750,7 +749,7 @@ const WorkspacePage = () => {
             <button
               onClick={() => navigate("/")}
               className="text-white hover:text-gray-300 transition-colors p-1"
-              title="Quay về trang chọn workspace"
+              title="Quay v�� trang chọn workspace"
             >
               <svg
                 width="20"

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -254,6 +254,15 @@ const WorkspacePage = () => {
         }
       });
 
+      wsSync.on("playback_ended_sync", (message) => {
+        console.log("🏁 Server playback ended - clearing state");
+        setCurrentSong(null);
+        setStatus("paused");
+        setIsLocallyPaused(false);
+        setSyncedPosition(0);
+        setServerPlaybackState(null);
+      });
+
       wsSync.on("error", (message) => {
         console.error("❌ WebSocket error:", message);
         setWsConnected(false);


### PR DESCRIPTION
This pull request adds the `concurrently` package as a dev dependency and updates the development scripts to support running both client and server simultaneously.

Changes made:
- Added `concurrently` v9.2.0 as a dev dependency in package.json
- Updated `dev` script to run both server and client concurrently
- Added new `dev:client` script that runs the original vite command
- Added new `dev:server` script that starts the server from the server directory
- Updated package-lock.json with concurrently and its dependencies (chalk, rxjs, shell-quote, tree-kill, supports-color, has-flag)

The WebSocket server implementation has been enhanced with new message handlers:
- Added handlers for server_play, client_pause, client_resume, playback_ended, get_room_state, and add_song
- Added queue support to room state
- Updated client connection logic to send current server state
- Modified play/pause handling to distinguish between local client actions and server-controlled playback

The workspace page has been updated to improve video validation and server synchronization:
- Enhanced video validation to check validity before adding to queue
- Improved error handling and user feedback during video validation
- Updated song addition logic to work with server-side queue management
- Modified player event handlers to work with server-controlled playback state
- Changed play/pause behavior to support local control while maintaining server sync

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ac0f167182d45d2a7fd536dff772db3/spark-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ac0f167182d45d2a7fd536dff772db3</projectId>-->
<!--<branchName>spark-lab</branchName>-->